### PR TITLE
Add support for sending encrypted pings

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,29 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-async function sendPing() {
-  const currentDate = new Date();
-
-  const payload = {
-    datetime: currentDate,
-  };
-
-  const options = {
-    schemaName: "debug",
-    schemaVersion: 1,
-  };
-
-  // FIXME pass messages to core add-on
-  throw new Error("not implemented");
-}
-
 let ion = new Ion();
-ion.initialize();
-
-sendPing()
-  .then((result) =>
-    console.info(
-      "Telemetry submitted, check about:telemetry archived ping data."
-    )
-  )
-  .catch((error) => console.error("Could not send ping:", error));
+ion.initialize(
+  // A sample key id used for encrypting data.
+  "sample-invalid-key-id",
+  // A sample *valid* JWK object for the encryption.
+  {
+    "kty":"EC",
+    "crv":"P-256",
+    "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+    "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+    "kid":"Public key used in JWS spec Appendix A.3 example"
+  }
+);

--- a/ion.js
+++ b/ion.js
@@ -8,9 +8,29 @@ const ION_SIGNUP_URL = "https://mozilla-ion.github.io/ion-core-addon/";
 class Ion {
   /**
    * Initialize the Ion library.
+   *
+   * @param {String} keyId
+   *        The id of the key used to encrypt outgoing data.
+   * @param {Object} key
+   *        The JSON Web Key (JWK) used to encrypt the outgoing data.
+   *        See the RFC 7517 https://tools.ietf.org/html/rfc7517
+   *        for additional information. For example:
+   *
+   *        {
+   *          "kty":"EC",
+   *          "crv":"P-256",
+   *          "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+   *          "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+   *          "kid":"Public key used in JWS spec Appendix A.3 example"
+   *        }
    */
-  async initialize() {
+  async initialize(keyId, key) {
     console.debug("Ion.initialize");
+
+    this._validateEncryptionKey(keyId, key);
+
+    this._keyId = keyId;
+    this._key = key;
 
     await this._checkIonCore().then(
         () => console.debug("Ion.initialize - Found Ion Core")
@@ -21,6 +41,10 @@ class Ion {
     // Listen for incoming messages from the Core addon.
     browser.runtime.onMessageExternal.addListener(
       (m, s) => this._handleExternalMessage(m, s));
+
+    // We went through the whole init process, it's now safe
+    // to use the Ion public APIs.
+    this._initialized = true;
   }
 
   /**
@@ -68,6 +92,81 @@ class Ion {
       default:
         return Promise.reject(
           new Error(`Ion._handleExternalMessage - unexpected message type ${message.type}`));
+    }
+  }
+
+  /**
+   * Validate the provided encryption keys.
+   *
+   * @param {String} keyId
+   *        The id of the key used to encrypt outgoing data.
+   * @param {Object} key
+   *        The JSON Web Key (JWK) used to encrypt the outgoing data.
+   *        See the RFC 7517 https://tools.ietf.org/html/rfc7517
+   *        for additional information. For example:
+   *
+   *        {
+   *          "kty":"EC",
+   *          "crv":"P-256",
+   *          "x":"f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+   *          "y":"x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+   *          "kid":"Public key used in JWS spec Appendix A.3 example"
+   *        }
+   *
+   * @throws {Error} if either the key id or the JWK key object are
+   *         invalid.
+   */
+  _validateEncryptionKey(keyId, key) {
+    if (typeof keyId !== "string") {
+      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key id ${keyId}`);
+    }
+
+    if (typeof key !== "object") {
+      throw new Error(`Ion._validateEncryptionKey - Invalid encryption key ${key}`);
+    }
+  }
+
+  /**
+   * Submit an encrypted ping through the Ion Core addon.
+   *
+   * @param {String} payloadType
+   *        The type of the encrypted payload. This will define the
+   *        `schemaName` of the ping.
+   * @param {Object} payload
+   *        A JSON-serializable payload to be sent with the ping.
+   */
+  async sendPing(payloadType, payload) {
+    if (!this._initialized) {
+      console.error("Ion.sendPing - Not initialzed, call `initialize()`");
+      return;
+    }
+
+    // Wrap everything in a try block, as we don't really want
+    // data collection to be the culprit of a bug hindering user
+    // experience.
+    try {
+      // The unique identifier of the study can be used as the
+      // namespace, in order to make sure data is routed to the
+      // proper analysis sandbox.
+      let studyName = browser.runtime.id;
+
+      // This function may be mistakenly called while init has not
+      // finished. Let's be safe and check for key validity again.
+      this._validateEncryptionKey(this._keyId, this._key);
+
+      const msg = {
+        type: "telemetry-ping",
+        data: {
+          payloadType: payloadType,
+          payload: payload,
+          namespace: studyName,
+          keyId: this._keyId,
+          key: this._key
+        }
+      }
+      await browser.runtime.sendMessage(CORE_ADDON_ID, msg, {});
+    } catch (ex) {
+      console.error(`Ion.sendPing - error while sending ${payloadType}`, ex);
     }
   }
 };


### PR DESCRIPTION
This adds the ion function to send encrypted pings through the core addon, using the study provided encryption keys.

Note that this will work as soon as mozilla-ion/ion-core-addon#78 is merged.