### PR TITLE
Remove the "management" permission from the template

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     }
   },
 
-  "permissions": ["management"],
+  "permissions": [],
 
   "background": {
     "scripts": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "@mozilla/rally": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@mozilla/rally/-/rally-0.0.2.tgz",
-      "integrity": "sha512-GB5YuaV7o2CMCSqY6eKXTdHGhwzGAdqdwjFTUUaEyljh+BJg2ALh3zjfaIPginPhyE84fqVjf1SuQL5lBde7lA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@mozilla/rally/-/rally-0.0.3.tgz",
+      "integrity": "sha512-MULsa3KFe9dfupsYY5f6fvYf40zesnAORCJRE9ngMyiBkW97Gi0tJ7Y+HQoQkEXbT3udAGNOikrrD8KF34OJog==",
       "dev": true
     },
     "@rollup/plugin-commonjs": {
@@ -940,6 +940,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true,
       "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -2450,6 +2460,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -6464,6 +6481,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && web-ext run"
   },
   "devDependencies": {
-    "@mozilla/rally": "^0.0.2",
+    "@mozilla/rally": "0.0.3",
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^10.0.0",
     "eslint": "^7.12.1",


### PR DESCRIPTION
This is no longer required by the partner support library 0.0.3.

See mozilla-ion/ion-core-addon#190.